### PR TITLE
Update for 2016.3.x changes

### DIFF
--- a/msdtc/map.jinja
+++ b/msdtc/map.jinja
@@ -9,6 +9,7 @@
   key:values here that differ from whats in defaults.yml
 ##}
 {% set osrelease_map = salt['grains.filter_by']({
+    '2012ServerR2': {},
     '2012Server': {},
     '2008ServerR2': {},
   }

--- a/msdtc/registry.sls
+++ b/msdtc/registry.sls
@@ -51,7 +51,6 @@ msdtc-network-access-registry:
     - vname: NetworkDtcAccess
     - vdata: {{ lookup.registry.get(msdtc.security.network_access.enabled) }}
     - vtype: REG_DWORD
-    - reflection: False
 
 {##
   Allow remote administration
@@ -62,7 +61,6 @@ msdtc-network-access-admin-registry:
     - vname: NetworkDtcAccessAdmin
     - vdata: {{ lookup.registry.get(msdtc.security.network_access.admin_enabled) }}
     - vtype: REG_DWORD
-    - reflection: False
 
 {##
   Allow remote clients
@@ -73,7 +71,6 @@ msdtc-network-access-client-registry:
     - vname: NetworkDtcAccessClients
     - vdata: {{ lookup.registry.get(msdtc.security.network_access.client_enabled) }}
     - vtype: REG_DWORD
-    - reflection: False
 
 msdtc-network-access-inbound-registry:
   reg.present:
@@ -81,7 +78,6 @@ msdtc-network-access-inbound-registry:
     - vname: NetworkDtcAccessInbound
     - vdata: {{ lookup.registry.get(msdtc.security.network_access.inbound_enabled) }}
     - vtype: REG_DWORD
-    - reflection: False
 
 msdtc-network-access-outbound-registry:
   reg.present:
@@ -89,7 +85,6 @@ msdtc-network-access-outbound-registry:
     - vname: NetworkDtcAccessOutbound
     - vdata: {{ lookup.registry.get(msdtc.security.network_access.outbound_enabled) }}
     - vtype: REG_DWORD
-    - reflection: False
 
 msdtc-network-access-transactions-registry:
   reg.present:
@@ -97,7 +92,6 @@ msdtc-network-access-transactions-registry:
     - vname: NetworkDtcAccessTransactions
     - vdata: {{ transactions_enabled }}
     - vtype: REG_DWORD
-    - reflection: False
 
 {##
   SNA LU 6.2 transaction protocol:
@@ -109,7 +103,6 @@ msdtc-transactions-lu-registry:
     - vname: LuTransactions
     - vdata: {{ lookup.registry.get(msdtc.security.transactions.lu_enabled) }}
     - vtype: REG_DWORD
-    - reflection: False
 
 {##
   XA Open TCP transaction protocol:
@@ -121,7 +114,6 @@ msdtc-transactions-xa-registry:
     - vname: XaTransactions
     - vdata: {{ lookup.registry.get(msdtc.security.transactions.xa_enabled) }}
     - vtype: REG_DWORD
-    - reflection: False
 
 msdtc-secure-rpc-registry:
   reg.present:
@@ -129,7 +121,6 @@ msdtc-secure-rpc-registry:
     - vname: AllowOnlySecureRpcCalls
     - vdata: {{ auth_type['mutual'] }}
     - vtype: REG_DWORD
-    - reflection: False
 
 msdtc-unsecure-rpc-registry:
   reg.present:
@@ -137,7 +128,6 @@ msdtc-unsecure-rpc-registry:
     - vname: FallbackToUnsecureRPCIfNecessary
     - vdata: {{ auth_type['incoming'] }}
     - vtype: REG_DWORD
-    - reflection: False
 
 msdtc-no-rpc-registry:
   reg.present:
@@ -145,5 +135,3 @@ msdtc-no-rpc-registry:
     - vname: TurnOffRpcSecurity
     - vdata: {{ auth_type['none'] }}
     - vtype: REG_DWORD
-    - reflection: False
-


### PR DESCRIPTION
**Summary**
- Add 2012ServerR2 to map.jinja to account for changes to the osrelease grain coming in 2016.3.x.
- Remove the reflection parameter of [_reg.present_](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.reg.html) (deprecated since version 2015.8.2).
